### PR TITLE
refactor: Corregir hallazgos de SonarCloud en módulos de alergias

### DIFF
--- a/src/main/java/com/historialplus/historialplus/internal/allergycatalog/service/AllergyCatalogServiceImpl.java
+++ b/src/main/java/com/historialplus/historialplus/internal/allergycatalog/service/AllergyCatalogServiceImpl.java
@@ -54,7 +54,7 @@ public class AllergyCatalogServiceImpl implements AllergyCatalogService{
     public AllergyCatalogDto findById(UUID id) {
         return allergyCatalogRepository.findById(id)
                 .map(allergyCatalogMapper::toDto)
-                .orElseThrow(() -> new NotFoundException("Alergia no encontrada en el catálogo con ID: " + id));
+                .orElseThrow(() -> allergyNotFoundException(id));
     }
 
     @Override
@@ -68,7 +68,7 @@ public class AllergyCatalogServiceImpl implements AllergyCatalogService{
     @Transactional
     public AllergyCatalogDto update(UUID id, AllergyCatalogRequestDto dto) {
         AllergyCatalogEntity existingEntity = allergyCatalogRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Alergia no encontrada en el catálogo con ID: " + id));
+                .orElseThrow(() -> allergyNotFoundException(id));
 
         if (allergyCatalogRepository.existsByNameIgnoreCaseAndIdNot(dto.getName(), id)) {
             throw new ConflictException("Ya existe otra alergia en el catálogo con el nombre: " + dto.getName());
@@ -83,7 +83,7 @@ public class AllergyCatalogServiceImpl implements AllergyCatalogService{
     @Transactional
     public AllergyCatalogDto deactivate(UUID id) {
         AllergyCatalogEntity entity = allergyCatalogRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Alergia no encontrada en el catálogo con ID: " + id));
+                .orElseThrow(() -> allergyNotFoundException(id));
 
         entity.setIsActive(false);
         AllergyCatalogEntity savedEntity = allergyCatalogRepository.save(entity);
@@ -94,10 +94,14 @@ public class AllergyCatalogServiceImpl implements AllergyCatalogService{
     @Transactional
     public AllergyCatalogDto reactivate(UUID id) {
         AllergyCatalogEntity entity = allergyCatalogRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Alergia no encontrada en el catálogo con ID: " + id));
+                .orElseThrow(() -> allergyNotFoundException(id));
 
         entity.setIsActive(true);
         AllergyCatalogEntity savedEntity = allergyCatalogRepository.save(entity);
         return allergyCatalogMapper.toDto(savedEntity);
+    }
+
+    private NotFoundException allergyNotFoundException(UUID id) {
+        return new NotFoundException("Alergia no encontrada en el catálogo con ID: " + id);
     }
 }

--- a/src/main/java/com/historialplus/historialplus/internal/patientallergy/service/PatientAllergyServiceImpl.java
+++ b/src/main/java/com/historialplus/historialplus/internal/patientallergy/service/PatientAllergyServiceImpl.java
@@ -31,18 +31,18 @@ public class PatientAllergyServiceImpl implements PatientAllergyService {
     @Override
     @Transactional
     public PatientAllergyResponseDto assignToRecord(AssignPatientAllergyDto dto) {
-        RecordEntity record = recordRepository.findById(dto.getRecordId())
+        RecordEntity medicalRecord = recordRepository.findById(dto.getRecordId())
                 .orElseThrow(() -> new NotFoundException("Historial médico no encontrado con ID: " + dto.getRecordId()));
 
         AllergyCatalogEntity allergy = allergyCatalogRepository.findById(dto.getAllergyCatalogId())
                 .orElseThrow(() -> new NotFoundException("Alergia no encontrada en el catálogo con ID: " + dto.getAllergyCatalogId()));
 
-        if (patientAllergyRepository.existsByMedicalRecord_IdAndAllergy_Id(record.getId(), allergy.getId())) {
+        if (patientAllergyRepository.existsByMedicalRecord_IdAndAllergy_Id(medicalRecord.getId(), allergy.getId())) {
             throw new ConflictException("El paciente ya tiene esta alergia asignada.");
         }
 
         PatientAllergyEntity newAssignedAllergy = PatientAllergyEntity.builder()
-                .medicalRecord(record)
+                .medicalRecord(medicalRecord)
                 .allergy(allergy)
                 .severity(dto.getSeverity())
                 .reactionDescription(dto.getReactionDescription())


### PR DESCRIPTION
### Cambios Implementados

**1. Renombrar Variable `record` en `PatientAllergyServiceImpl`**
   - **Problema (SonarCloud):** Se estaba utilizando `record` como nombre de variable, lo cual es una palabra clave contextual en Java desde la versión 14 y puede generar confusión.
   - **Solución:** Se ha renombrado la variable a `medicalRecord` para eliminar la ambigüedad y seguir las buenas prácticas.

**2. Centralizar Mensajes de Error Duplicados en `AllergyCatalogServiceImpl`**
   - **Problema (SonarCloud):** El mensaje de error `"Alergia no encontrada en el catálogo con ID: "` se estaba repitiendo en múltiples lugares, violando el principio DRY.
   - **Solución:** Se ha creado un método de ayuda privado (`allergyNotFoundException`) que centraliza la creación de la `NotFoundException`, haciendo el código más fácil de mantener.